### PR TITLE
Complete diagnostic for JS reference types

### DIFF
--- a/lib/diagnostic.js
+++ b/lib/diagnostic.js
@@ -6,14 +6,30 @@
 // splits it into an array of normalized words
 // (uppercase strings without punctuation)
 // and returns that array.
-const normalizeWords = function (/* */) {
-  /* your response here */
+const normalizeWords = function (words) {
+  words = words.split(/\s+/);
+  return words.map(function (word) {
+    return word.toUpperCase().replace(/\W+/, '');
+  });
 };
 
 // 2. Write a function that takes a string argument
 // and returns an array of unique normalized words.
-const uniqueWords = function (/* */) {
-  /* your response here */
+const uniqueWords = function (words) {
+  let uniqueWords = [];
+  let uniqueWordsAsKeys = {};
+  const normalizedWords = normalizeWords(words);
+
+  for (let i = 0; i < normalizedWords.length; i++) {
+    let word = normalizedWords[i];
+    uniqueWordsAsKeys[word] = true;
+  }
+
+  for (let prop in uniqueWordsAsKeys) {
+    uniqueWords.push(prop);
+  }
+
+  return uniqueWords;
 };
 
 // 3. Write a function that takes a string argument and returns the count of
@@ -21,14 +37,31 @@ const uniqueWords = function (/* */) {
 // Provide the *option* to count unique words instead of total words, by passing
 // a second argument.
 
-const wordCount = function (/* */) {
-  /* your response here */
+const wordCount = function (words, option) {
+  const normalizedWords = normalizeWords(words);
+  const uniqueWordsArray = uniqueWords(words);
+
+  if (option) {
+    return uniqueWordsArray.length;
+  } else {
+    return normalizedWords.length;
+  }
 };
 
 // 4. Write a function that takes a string and returns a dictionary with unique
 // words as keys and a count of each word as the value for that key
-const wordFrequencies = function (/* */) {
-  /* your response here */
+const wordFrequencies = function (words) {
+  let wordFrequencies = {};
+  const normalizedWords = normalizeWords(words);
+
+  normalizedWords.forEach(function (word) {
+    if (wordFrequencies[word]) {
+      wordFrequencies[word] += 1;
+    } else {
+      wordFrequencies[word] = 1;
+    }
+  });
+  return wordFrequencies;
 };
 
 module.exports = {


### PR DESCRIPTION
Provided answers for all 4 incomplete functions. Verified green tests.

Comfort: 4/5
Clarity: 5/5

I used my answers to yesterday's lab for most of these questions. I also looked at the tests that were written when my first function was not working. Unlike yesterday's lab, splitting the `normalizedWords` array on a space was not sufficient. I changed it to use regular expression for whitespace shown in the test. 